### PR TITLE
Replaced removed loading functions with Cesium.Resource (Required for Cesium1.44)

### DIFF
--- a/3dwebclient/script.js
+++ b/3dwebclient/script.js
@@ -976,7 +976,7 @@ function fetchDataFromGoogleFusionTable(gmlid, thematicDataUrl) {
     var sql = "SELECT * FROM " + tableID + " WHERE GMLID = '" + gmlid + "'";
     var apiKey = "AIzaSyAm9yWCV7JPCTHCJut8whOjARd7pwROFDQ";
     var queryLink = "https://www.googleapis.com/fusiontables/v2/query";
-    new Cesium.Resource({ url: queryLink, queryParameters: {sql, key: apiKey} }).fetch({ responseType: 'json' }).then(function(data) {
+    new Cesium.Resource({ url: queryLink, queryParameters: {sql: sql, key: apiKey} }).fetch({ responseType: 'json' }).then(function(data) {
         console.log(data);
         var columns = data.columns;
         var rows = data.rows;

--- a/3dwebclient/script.js
+++ b/3dwebclient/script.js
@@ -977,7 +977,7 @@ function fetchDataFromGoogleFusionTable(gmlid, thematicDataUrl) {
     var apiKey = "AIzaSyAm9yWCV7JPCTHCJut8whOjARd7pwROFDQ";
     var queryLink = "https://www.googleapis.com/fusiontables/v2/query?" + sql + "&key=" + apiKey;
 
-    Cesium.loadJson(queryLink).then(function (data) {
+    new Cesium.Resource({ url: queryLink }).fetch({ responseType: 'json' }).then(function(data) {
         console.log(data);
         var columns = data.columns;
         var rows = data.rows;

--- a/3dwebclient/script.js
+++ b/3dwebclient/script.js
@@ -973,11 +973,10 @@ function fetchDataFromGoogleFusionTable(gmlid, thematicDataUrl) {
     var deferred = Cesium.when.defer();
 
     var tableID = CitydbUtil.parse_query_string('docid', thematicDataUrl);
-    var sql = "sql=SELECT * FROM " + tableID + " WHERE GMLID = '" + gmlid + "'";
+    var sql = "SELECT * FROM " + tableID + " WHERE GMLID = '" + gmlid + "'";
     var apiKey = "AIzaSyAm9yWCV7JPCTHCJut8whOjARd7pwROFDQ";
-    var queryLink = "https://www.googleapis.com/fusiontables/v2/query?" + sql + "&key=" + apiKey;
-
-    new Cesium.Resource({ url: queryLink }).fetch({ responseType: 'json' }).then(function(data) {
+    var queryLink = "https://www.googleapis.com/fusiontables/v2/query";
+    new Cesium.Resource({ url: queryLink, queryParameters: {sql, key: apiKey} }).fetch({ responseType: 'json' }).then(function(data) {
         console.log(data);
         var columns = data.columns;
         var rows = data.rows;

--- a/js/CitydbKmlDataSource.js
+++ b/js/CitydbKmlDataSource.js
@@ -54,8 +54,6 @@
     var Iso8601 = Cesium.Iso8601;
     var joinUrls = Cesium.joinUrls;
     var JulianDate = Cesium.JulianDate;
-    var loadBlob= Cesium.loadBlob;
-    var loadXML = Cesium.loadXML;
     var CesiumMath = Cesium.CesiumMath;
     var NearFarScalar = Cesium.NearFarScalar;
     var PinBuilder = Cesium.PinBuilder;
@@ -856,7 +854,7 @@
 
     //Asynchronously processes an external style file.
     function processExternalStyles(dataSource, uri, styleCollection) {
-        return loadXML(proxyUrl(uri, dataSource._proxy)).then(function(styleKml) {
+        return new Cesium.Resource({ url: proxyUrl(uri, dataSource._proxy) }).fetchXml().then(function(styleKml) {
             return processStyles(dataSource, styleKml, styleCollection, uri, true);
         });
     }
@@ -2259,7 +2257,7 @@
 
         var promise = data;
         if (typeof data === 'string') {
-            promise = loadBlob(proxyUrl(data, dataSource._proxy));
+            promise = new Cesium.Resource({ url: proxyUrl(data, dataSource._proxy) }).fetch({ responseType: 'blob' });
             sourceUri = defaultValue(sourceUri, data);
         }
 

--- a/js/CitydbKmlLayer.js
+++ b/js/CitydbKmlLayer.js
@@ -289,7 +289,7 @@
 	function loadMasterJSON(that, isFirstLoad) {
 		var deferred = Cesium.when.defer();
 		var jsonUrl = that._url;
-		Cesium.loadJson(jsonUrl).then(function(json) {        	
+		new Cesium.Resource({ url: jsonUrl }).fetch({ responseType: 'json' }).then(function(json) { 	
         	that._jsonLayerInfo = json;	
         	that._layerType = json.displayform;
             that._cameraPosition = {
@@ -316,7 +316,7 @@
             
             var cityobjectsJsonUrl = that._cityobjectsJsonUrl;
             if (Cesium.defined(cityobjectsJsonUrl)) {
-            	Cesium.loadJson(cityobjectsJsonUrl).then(function(data) {
+            	new Cesium.Resource({ url: cityobjectsJsonUrl }).fetch({ responseType: 'json' }).then(function(data) {
 					deferred.resolve(that);
 					that._cityobjectsJsonData = data;
 				}).otherwise(function() {


### PR DESCRIPTION
Hi all

As mentioned in #27 , some changes regarding the loading of external resources are necessary to update to the most recent Cesium version (which is 1.44). In fact, it's not that much, but they are still breaking, since the old functions have been completely removed.

This PR includes those changes that were necessary and from my tests, the 3dwebclient viewer works as before. As you specified, I did not include the updated Cesium version. (Which is yet another thing I'd like to work on - as mentioned in #24 . Using node correctly, we could simplify deployments of the 3D Client, by not having to also distribute the Cesium libraries along with the code :-))

Please let me know should you find any issues, so I can update them.

Best,
Lukas